### PR TITLE
[TECH-1647] Storybook 6.4 update - Remove staticDir option from script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,4 +4,4 @@ BUILD_DIR=$1
 
 cd $BUILD_DIR
 
-npm run build-storybook -- -s public/storybook,frontend -o public/storybook
+npm run build-storybook -- -o public/storybook


### PR DESCRIPTION
[AnyRoad Repo PR](https://github.com/anyroadcom/anyroad/pull/6165)

`staticDir` option is deprecated in the CLI for Storybook v6.4